### PR TITLE
Redirect to reminder overview (instead of error)

### DIFF
--- a/new_reminder.php
+++ b/new_reminder.php
@@ -73,6 +73,10 @@ $mform = new reminder_form($PAGE->url,
 if ($mform->is_cancelled()) {
     // Handle form cancel operation, if cancel button is present on form.
     $df = 1;
+    
+    // Go back to course
+    $url = new moodle_url('/course/view.php', array('id' => $PAGE->course->id));
+    redirect($url);
 } else if ($fromform = $mform->get_data()) {
     // In this case you process validated data. $mform->get_data() returns data posted in form.
     if ($fromform->id == 0) {

--- a/new_reminder.php
+++ b/new_reminder.php
@@ -74,8 +74,8 @@ if ($mform->is_cancelled()) {
     // Handle form cancel operation, if cancel button is present on form.
     $df = 1;
     
-    // Go back to course
-    $url = new moodle_url('/course/view.php', array('id' => $PAGE->course->id));
+    // Go back to reminder overview
+    $url = new moodle_url('/blocks/dukreminder/course_reminders.php', array('courseid' => $PAGE->course->id));
     redirect($url);
 } else if ($fromform = $mform->get_data()) {
     // In this case you process validated data. $mform->get_data() returns data posted in form.


### PR DESCRIPTION
Canceling the creation of a reminder lead to an error.

With these changes the user will be redirected to the reminder overview page
`/moodle/blocks/dukreminder/course_reminders.php?courseid=123`
after canceling.
